### PR TITLE
fix database connection timeout

### DIFF
--- a/casbin_sqlalchemy_adapter/adapter.py
+++ b/casbin_sqlalchemy_adapter/adapter.py
@@ -50,6 +50,7 @@ class Adapter(persist.Adapter):
         lines = self._session.query(CasbinRule).all()
         for line in lines:
             persist.load_policy_line(str(line), model)
+        self._commit()
 
     def _save_policy_line(self, ptype, rule):
         line = CasbinRule(ptype=ptype)


### PR DESCRIPTION
When `casbin.Enforcer` is created, `Adapter.load_policy()` will be called,
but sqlalchemy session is not commited in `Adapter.load_policy()`. The
connection to database is held all the time till the first database
operation, if the time interval between `casbin.Enforcer` created and
first database operation occurs, exceeds database timeout setting, database
operations like `add_policy()` and `remove_policy()` will raise timeout
exception.