### PR TITLE
fix: cannot see the insert/update/delete records from other transacti…

### DIFF
--- a/casbin_sqlalchemy_adapter/adapter.py
+++ b/casbin_sqlalchemy_adapter/adapter.py
@@ -70,7 +70,7 @@ class Adapter(persist.Adapter):
 
     def load_filtered_policy(self, model, filter) -> None:
         """loads all policy rules from the storage."""
-
+        self._commit()  # Commit transaction, so you can see the insert/update/delete from other transaction when use multi processes(eg. Nginx reverse proxy)
         self._filtered = True
         query = self._session.query(self._db_class)
         filters = []
@@ -103,10 +103,10 @@ class Adapter(persist.Adapter):
 
     def load_policy(self, model):
         """loads all policy rules from the storage."""
+        self._commit()  # Commit transaction, so you can see the insert/update/delete from other transaction when use multi processes(eg. Nginx reverse proxy)
         lines = self._session.query(self._db_class).all()
         for line in lines:
             persist.load_policy_line(str(line), model)
-        self._commit()
 
     def _save_policy_line(self, ptype, rule):
         line = self._db_class(ptype=ptype)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -132,7 +132,11 @@ class TestConfig(TestCase):
 
         enforcer.get_model().clear_policy()
 
-        enforcer.load_filtered_policy(PolicyFilter(p=(Filter(v0="alice")), g=(Filter(v0="alice"))))
-        self.assertFalse(enforcer.enforce("alice", "data1", "read"))
+        enforcer.load_filtered_policy(PolicyFilter(p=(Filter(v0="alice"),), g=(Filter(v0="alice"),)))  # PolicyFilter.p and PolicyFilter.g need to be iterable(eg. set(),  Notice the comma at the end)
+        """
+        p, alice, data1, read
+        g, alice, data2_admin
+        """
+        self.assertTrue(enforcer.enforce("alice", "data1", "read"))
         self.assertFalse(enforcer.enforce("bob", "data2", "write"))
-        self.assertTrue(enforcer.enforce("alice", "data2", "write"))
+        self.assertFalse(enforcer.enforce("alice", "data2", "write"))


### PR DESCRIPTION
**[Fix] cannot see the insert/update/delete records from other transaction when use multi processes(eg. Nginx reverse proxy)**

If you start two processes:  transaction01 for process01, and transaction02 for process02
The default isolation level of MySQL is RR
When you insert/update/delete from transaction01, then transaction02 can't see the modify

We need to:
1. Before you call `e.enforce(sub, obj, act)`，need to call `e.load_policy()`
2. In `e.load_policy()`, we need to commit the transaction before execute the SELECT SQL 
