### PR TITLE
feat: replace declarative_base -> DeclarativeBase for sqlalchemy 2.0 migration

### DIFF
--- a/casbin_sqlalchemy_adapter/adapter.py
+++ b/casbin_sqlalchemy_adapter/adapter.py
@@ -3,10 +3,11 @@ from contextlib import contextmanager
 from casbin import persist
 from sqlalchemy import Column, Integer, String
 from sqlalchemy import create_engine, or_
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
 
-Base = declarative_base()
+# declarative base class
+class Base(DeclarativeBase):
+    pass
 
 
 class CasbinRule(Base):
@@ -288,3 +289,4 @@ class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
             # return deleted rules
 
             return old_rules
+

--- a/casbin_sqlalchemy_adapter/adapter.py
+++ b/casbin_sqlalchemy_adapter/adapter.py
@@ -289,4 +289,3 @@ class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
             # return deleted rules
 
             return old_rules
-


### PR DESCRIPTION
fix warning:
MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)