### PR TITLE
feat: DeclarativeBase import fails with SQLAlchemy 1.x

### DIFF
--- a/casbin_sqlalchemy_adapter/adapter.py
+++ b/casbin_sqlalchemy_adapter/adapter.py
@@ -1,13 +1,22 @@
 from contextlib import contextmanager
 
+import sqlalchemy
 from casbin import persist
 from sqlalchemy import Column, Integer, String
 from sqlalchemy import create_engine, or_
-from sqlalchemy.orm import sessionmaker, DeclarativeBase
+from sqlalchemy.orm import sessionmaker
 
 # declarative base class
-class Base(DeclarativeBase):
-    pass
+if sqlalchemy.__version__.startswith("1."):
+    from sqlalchemy.orm import declarative_base
+
+    Base = declarative_base()
+
+else:
+    from sqlalchemy.orm import DeclarativeBase
+
+    class Base(DeclarativeBase):
+        pass
 
 
 class CasbinRule(Base):


### PR DESCRIPTION
Fix for the following when installed version of SQLAlchemy is < 2.0 (requirements still list `SQLAlchemy>=1.2.18`):
```
>>> from casbin_sqlalchemy_adapter import Adapter
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../lib/python3.11/site-packages/casbin_sqlalchemy_adapter/__init__.py", line 1, in <module>
    from .adapter import CasbinRule, Adapter, Base
  File ".../lib/python3.11/site-packages/casbin_sqlalchemy_adapter/adapter.py", line 6, in <module>
    from sqlalchemy.orm import sessionmaker, DeclarativeBase
ImportError: cannot import name 'DeclarativeBase' from 'sqlalchemy.orm' (.../lib/python3.11/site-packages/sqlalchemy/orm/__init__.py)__init__.py)
```