### PR TITLE
feat: Add the option to suppress MetaData.create_all call

### DIFF
--- a/casbin_sqlalchemy_adapter/adapter.py
+++ b/casbin_sqlalchemy_adapter/adapter.py
@@ -56,7 +56,7 @@ class Filter:
 class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
     """the interface for Casbin adapters."""
 
-    def __init__(self, engine, db_class=None, filtered=False):
+    def __init__(self, engine, db_class=None, filtered=False, create_all_models=True):
         if isinstance(engine, str):
             self._engine = create_engine(engine)
         else:
@@ -82,7 +82,8 @@ class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
         self._db_class = db_class
         self.session_local = sessionmaker(bind=self._engine)
 
-        Base.metadata.create_all(self._engine)
+        if create_all_models:
+            Base.metadata.create_all(self._engine)
         self._filtered = filtered
 
     @contextmanager


### PR DESCRIPTION
In some of our environments the call `Metadata.create_all` causes an exception. While beeing aware that this is technically an issue on our side, it would be nice to leave the responsibility of the state of the environment to the user and be able to suppress this call.